### PR TITLE
AMAZON.PauseIntent, AMAZON.ResumeIntent are now required

### DIFF
--- a/src/skill/models/intentSchema.json
+++ b/src/skill/models/intentSchema.json
@@ -28,6 +28,12 @@
       "intent": "AMAZON.CancelIntent"
     },
     {
+     "intent":"AMAZON.PauseIntent"
+    }, 
+    {
+     "intent":"AMAZON.ResumeIntent"
+    },
+    {
       "intent": "BeginIntent"
     },
     {


### PR DESCRIPTION
When adding the **Intent Schema** in the _Amazon DEVELOPER CONSOLE_
The following exception is raised
![screen shot 2016-12-01 at 12 22 54 am](https://cloud.githubusercontent.com/assets/6495684/20787604/9d1ea872-b761-11e6-9b0e-7a17d2f67bf3.png)

![screen shot 2016-12-01 at 1 01 57 am](https://cloud.githubusercontent.com/assets/6495684/20787656/de2140e6-b761-11e6-807b-c158fa129a1f.png)
